### PR TITLE
#12 Exposing quoteStrings export property

### DIFF
--- a/generic-table/directive/generic-table/generic-table.js
+++ b/generic-table/directive/generic-table/generic-table.js
@@ -415,7 +415,7 @@ angular.module('angular.generic.table').directive('genericTable', function() {
 
         // if exportColumns are passed with options...
         if (typeof options.exportColumns !== 'undefined') {
-            
+
             // ...get field settings for all objectKeys in exportColumns array
             var exportFields = $filter('map')(options.exportColumns, function(objectKey){
                 return $filter('filter')($scope.gtFields.slice(0), {objectKey:objectKey}, true)[0];
@@ -433,7 +433,8 @@ angular.module('angular.generic.table').directive('genericTable', function() {
             columnOrder:$filter('map')(exportFields,"objectKey"), // get column order
             decimalSep:typeof options.decimalSep === 'undefined' ? ',':options.decimalSep,
             addByteOrderMarker:typeof options.addBom === 'undefined',
-            charset:typeof options.charset === 'undefined' ? 'utf-8':options.charset
+            charset:typeof options.charset === 'undefined' ? 'utf-8':options.charset,
+            quoteStrings: typeof options.quoteStrings === 'undefined' ? false : options.quoteStrings
         };
 
         CSV.stringify(data, headers).then(function(result){


### PR DESCRIPTION
Makes it possible to set the quoteStrings in the underlaying call to ngCsv on export. This does not solve the full injection issue but its good to suport the escaping of strings as the underlying lib (ngCsv) does
